### PR TITLE
Create template

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,24 @@ Generate a screenshot of any public URL.
 image = client.url_to_image("https://github.com", viewport_width: 800, viewport_height: 1200)
 ```
 
+## Templates
+A template allows you to define HTML that includes variables to be substituted at the time of image creation. [Learn more about templates](https://docs.htmlcsstoimage.com/getting-started/templates/).
+
+```ruby
+template = client.create_template("<div>{{title}}</div>")
+# => #<HTMLCSSToImage::ApiResponse template_id="t-56c64be5-5861-4148-acec-aaaca452027f", template_version=1596829374001>
+
+# Get templates
+all_templates = client.templates
+
+# Create a signed URL for a templated image
+image = client.create_image_from_template(template.template_id, { title: "Hello, world!" })
+# => #<HTMLCSSToImage::ApiResponse url="https://hcti.io/v1/image/t-56c64be5-5861-4148-acec-aaaca452027f/3aaa814dd998b302cc62b3550ddb35e8b9117c5ecea286da904eced0a3f44d9e?title=Hello%2C%20world%21">
+
+image.url
+# => "https://hcti.io/v1/image/t-56c64be5-5861-4148-acec-aaaca452027f/3aaa814dd998b302cc62b3550ddb35e8b9117c5ecea286da904eced0a3f44d9e?title=Hello%2C%20world%21"
+```
+
 ### Additional methods
 See the [ruby-client docs for all of the available methods](https://htmlcsstoimage.github.io/ruby-client/HTMLCSSToImage.html).
 

--- a/bin/console
+++ b/bin/console
@@ -7,8 +7,5 @@ require "htmlcsstoimage"
 # with your gem easier. You can also use a different console, if you like.
 
 # (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
-
-require "irb"
-IRB.start(__FILE__)
+require "pry"
+Pry.start

--- a/cassettes/HTMLCSSToImage/_create_template/creates_a_new_template.yml
+++ b/cassettes/HTMLCSSToImage/_create_template/creates_a_new_template.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://hcti.io/v1/template
+    body:
+      encoding: UTF-8
+      string: '{"html":"<div>{{title}}</div>"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic authentication-header
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 07 Aug 2020 19:36:19 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - AWSALB=8NnODxuzAe4Nb8xeygtwkJHJHF3lssQ/enmnhpDWIEnVBlUCGsJx7oOuPNoHhhnOmfAuosIx+goxLrCc65Bj5aHNLx2OQfAT2+s30zwTqYe68r9E92BliiwyFa5u;
+        Expires=Fri, 14 Aug 2020 19:36:19 GMT; Path=/
+      - AWSALBCORS=8NnODxuzAe4Nb8xeygtwkJHJHF3lssQ/enmnhpDWIEnVBlUCGsJx7oOuPNoHhhnOmfAuosIx+goxLrCc65Bj5aHNLx2OQfAT2+s30zwTqYe68r9E92BliiwyFa5u;
+        Expires=Fri, 14 Aug 2020 19:36:19 GMT; Path=/; SameSite=None
+      - __cfduid=d711e0d3ad7d037601f11d9cf3adf2b781596828978; expires=Sun, 06-Sep-20
+        19:36:18 GMT; path=/; domain=.hcti.io; HttpOnly; SameSite=Lax
+      - __cflb=0H28vWzHFPHZw4TS8VrB813a2Y9bcaGDgdxkfUiw3uN; SameSite=Lax; path=/;
+        expires=Sat, 08-Aug-20 18:36:19 GMT; HttpOnly
+      Cf-Ray:
+      - 5bf3721e3a64ed8b-SJC
+      Access-Control-Allow-Origin:
+      - "*"
+      Vary:
+      - Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - 046c05a6e10000ed8b05ab1200000001
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Request-Context:
+      - appId=cid-v1:ef200074-f922-49b8-a889-360bb27d5561
+      Server:
+      - cloudflare
+    body:
+      encoding: ASCII-8BIT
+      string: '{"template_id":"t-5a518f6d-fc53-4c6a-96a1-34ef5ff89916","template_version":1596828979123}'
+  recorded_at: Fri, 07 Aug 2020 19:36:19 GMT
+recorded_with: VCR 6.0.0

--- a/lib/htmlcsstoimage.rb
+++ b/lib/htmlcsstoimage.rb
@@ -73,7 +73,6 @@ class HTMLCSSToImage
     response
   end
 
-
   # Creates a signed URL for generating an image from a template
   # This URL contains the template_values in it. It is signed with HMAC so that it cannot be changed
   # by anyone without the API Key.
@@ -125,5 +124,30 @@ class HTMLCSSToImage
   def templates(params = {})
     options = params.merge({ basic_auth: @auth })
     self.class.get("/v1/template", options)
+  end
+
+  # Creates an image template
+  #
+  # @see https://docs.htmlcsstoimage.com/getting-started/templates/
+  #
+  # @param html [String] This is the HTML you want to render. You can send an HTML snippet (`<div>Your content</div>`) or an entire webpage.
+  #
+  # @option params [String] :name A short name to identify your template max length 64
+  # @option params [String] :description Description to elaborate on the use of your template max length 1024
+  # @option params [String] :css The CSS for your image.
+  # @option params [String] :google_fonts [Google fonts](https://docs.htmlcsstoimage.com/guides/using-google-fonts/) to be loaded. Example: `Roboto`. Multiple fonts can be loaded like this: `Roboto|Open Sans`
+  # @option params [String] :selector A CSS selector for an element on the webpage. We'll crop the image to this specific element. For example: `section#complete-toolkit.container-lg`
+  # @option params [Integer] :ms_delay The number of milliseconds the API should delay before generating the image. This is useful when waiting for JavaScript. We recommend starting with `500`. Large values slow down the initial render time.
+  # @option params [Double] :device_scale This adjusts the pixel ratio for the screenshot. Minimum: `1`, Maximum: `3`.
+  # @option params [Boolean] :render_when_ready Set to true to control when the image is generated. Call `ScreenshotReady()` from JavaScript to generate the image. [Learn more](https://docs.htmlcsstoimage.com/guides/render-when-ready/).
+  # @option params [Integer] :viewport_width Set the width of Chrome's viewport. This will disable automatic cropping. Both height and width parameters must be set if using either.
+  # @option params [Integer] :viewport_height Set the height of Chrome's viewport. This will disable automatic cropping. Both height and width parameters must be set if using either.
+  #
+  # @return [HTMLCSSToImage::ApiResponse] image URL available at `.url`.
+  def create_template(html, params = {})
+    body = { html: html }.merge(params).to_json
+    options = { basic_auth: @auth, body: body }
+
+    self.class.post("/v1/template", options)
   end
 end

--- a/spec/htmlcsstoimage_spec.rb
+++ b/spec/htmlcsstoimage_spec.rb
@@ -67,6 +67,15 @@ RSpec.describe HTMLCSSToImage do
     end
   end
 
+  describe "#create_template", :vcr do
+    it "creates a new template" do
+      template = client.create_template("<div>{{title}}</div>")
+
+      expect(template.id).to_not be_nil
+      expect(template.version).to_not be_nil
+    end
+  end
+
   describe "#create_image_from_template" do
     it "generates a signed url for the image" do
       # The key is used to generate the token, so we hardcode it here

--- a/spec/htmlcsstoimage_spec.rb
+++ b/spec/htmlcsstoimage_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe HTMLCSSToImage do
     it "creates a new template" do
       template = client.create_template("<div>{{title}}</div>")
 
-      expect(template.id).to_not be_nil
+      expect(template.template_id).to_not be_nil
       expect(template.version).to_not be_nil
     end
   end

--- a/spec/htmlcsstoimage_spec.rb
+++ b/spec/htmlcsstoimage_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe HTMLCSSToImage do
       template = client.create_template("<div>{{title}}</div>")
 
       expect(template.template_id).to_not be_nil
-      expect(template.version).to_not be_nil
+      expect(template.template_version).to_not be_nil
     end
   end
 


### PR DESCRIPTION
Adding `create_template` to the client.

Allows you to create a template, and then use it to generate URLs from Ruby.

```ruby
template = client.create_template("<div>{{title}}</div>")
# => #<HTMLCSSToImage::ApiResponse template_id="t-56c64be5-5861-4148-acec-aaaca452027f", template_version=1596829374001>
# Get templates
all_templates = client.templates
# Create a signed URL for a templated image
image = client.create_image_from_template(template.template_id, { title: "Hello, world!" })
# => #<HTMLCSSToImage::ApiResponse url="https://hcti.io/v1/image/t-56c64be5-5861-4148-acec-aaaca452027f/3aaa814dd998b302cc62b3550ddb35e8b9117c5ecea286da904eced0a3f44d9e?title=Hello%2C%20world%21">
image.url
# => "https://hcti.io/v1/image/t-56c64be5-5861-4148-acec-aaaca452027f/3aaa814dd998b302cc62b3550ddb35e8b9117c5ecea286da904eced0a3f44d9e?title=Hello%2C%20world%21"
```