### PR TITLE
fix: OpenStruct causes NameError in Rake13.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Generate png, jpg or webp images with Ruby. Renders exactly like Google Chrome.
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'htmlcsstoimage-api'
+gem 'htmlcsstoimage-api', require: 'htmlcsstoimage'
 ```
 
 And then execute:
@@ -27,6 +27,7 @@ Or install it yourself as:
 Create a new instance of the API client.
 
 ```ruby
+require "htmlcsstoimage"
 # Retrieve your user id and api key from https://htmlcsstoimage.com/dashboard
 client = HTMLCSSToImage.new(user_id: "user-id", api_key: "api-key")
 ```
@@ -36,6 +37,7 @@ client = HTMLCSSToImage.new(user_id: "user-id", api_key: "api-key")
 Alternatively, you can set `ENV["HCTI_USER_ID"]` and `ENV["HCTI_API_KEY"]`. These will be loaded automatically.
 
 ```ruby
+require "htmlcsstoimage"
 client = HTMLCSSToImage.new
 ```
 

--- a/lib/htmlcsstoimage.rb
+++ b/lib/htmlcsstoimage.rb
@@ -1,6 +1,7 @@
 require "htmlcsstoimage/version"
 require "httparty"
 require "addressable"
+require "ostruct"
 
 class HTMLCSSToImage
   include HTTParty


### PR DESCRIPTION
resolves #5 
Loading of "ostruct" depends on Rake, so we need to explicitly load it and resolve the dependency. 
Because Rake does not load "ostruct" since version 13.2.0. 
[ruby/rake#545](https://github.com/ruby/rake/pull/545)